### PR TITLE
preserve loader "this" context for "replacement" function

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -17,7 +17,7 @@ module.exports = function(source) {
         if(typeof source === "string") {
             options.replacements.forEach(function(repl) {
                 source = source.replace(repl.pattern, repl.replacement.bind(this));
-            });
+            }, this);
         } else {
             this.emitWarning("'source' received by loader was not a string");
         }

--- a/loader.js
+++ b/loader.js
@@ -16,7 +16,7 @@ module.exports = function(source) {
 
         if(typeof source === "string") {
             options.replacements.forEach(function(repl) {
-                source = source.replace(repl.pattern, repl.replacement);
+                source = source.replace(repl.pattern, repl.replacement.bind(this));
             });
         } else {
             this.emitWarning("'source' received by loader was not a string");

--- a/test.js
+++ b/test.js
@@ -90,5 +90,32 @@ describe('StringReplacePlugin', function(){
             replaced = loader.call(mockConfig, "some <!-- @secret stuff --> string");
             assert.equal(replaced, "some replaced ==>stuff<== string", "replaces matches");
         });
+
+        it('should replace strings in source via options', function(){
+            mockConfig.options.replacement = {
+                before: 'replaced ==>',
+                after: '<=='
+            };
+            plugin.apply(mockConfig);
+
+            var replOpts = mockConfig.options[StringReplacePlugin.REPLACE_OPTIONS];
+
+            replOpts[id] = {
+                replacements: [{
+                    pattern: /<!-- @secret (\w*?) -->/ig,
+                    replacement: function (match, p1) {
+                        return this.options.replacement.before + p1 + this.options.replacement.after;
+                    }
+                }]
+            };
+
+            mockConfig.query = query;
+
+            var replaced = loader.call(mockConfig, "some string");
+            assert(replaced === "some string", "doesn't modify when there are no matches");
+
+            replaced = loader.call(mockConfig, "some <!-- @secret stuff --> string");
+            assert.equal(replaced, "some replaced ==>stuff<== string", "replaces matches");
+        });
     })
 });


### PR DESCRIPTION
It helps to save loader `this` context during replacement. It is very useful in case when you need to have access to `this` context, for instance `this.options`:

``` javascript
{
    test: /\.shtml$/,
    loader: StringReplacePlugin.replace('html-loader', {
        replacements: [{
            pattern: /{{publicPath}}/gi,
            replacement: function () {
                return this.options.output.publicPath;
            }
        }]
    })
}
```
