### PR TITLE
fixed the api doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ keys in modules prior to deployment.
 ## API
 
 ``` javascript
-StringReplacePlugin([nextLoaders: string], options, [prevLoaders: string])
+StringReplacePlugin.replace([nextLoaders: string], options, [prevLoaders: string])
 ```
 
 * `nextLoaders` loaders to follow the replacement


### PR DESCRIPTION
`StringReplacePlugin([nextLoaders: string], options, [prevLoaders: string])` made me misunderstand 

``` javascript
plugins: [
      // an instance of the plugin must be present
      new StringReplacePlugin([nextLoaders: string], options, [prevLoaders: string])
   ]
```
