### PR TITLE
preserve source map after replacement

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -5,7 +5,8 @@
 var loaderUtils = require("loader-utils");
 var StringReplacePlugin = require('./index.js');
 
-module.exports = function(source) {
+module.exports = function(source, map) {
+    var callback = this.async();
     var id = loaderUtils.parseQuery(this.query).id;
 
     var stringReplaceOptions = this.options[StringReplacePlugin.REPLACE_OPTIONS];
@@ -23,6 +24,6 @@ module.exports = function(source) {
         }
     }
 
-	this.cacheable && this.cacheable();
-	return source;
+    this.cacheable && this.cacheable();
+    callback(null, source, map);
 };

--- a/test.js
+++ b/test.js
@@ -3,7 +3,6 @@
  */
 var assert = require("assert");
 var StringReplacePlugin = require("./index.js");
-var mockConfig = { options: {}, emitWarning: console.log };
 
 describe('StringReplacePlugin', function(){
     describe('#replace()', function(){
@@ -62,7 +61,19 @@ describe('StringReplacePlugin', function(){
                 }]
             },
             id = null,
-            query = null;
+            query = null,
+            replaced = null;
+
+        var callback = function() {
+            return function(_, source) {
+                replaced = source;
+            };
+        };
+        var mockConfig = {
+            options: {},
+            emitWarning: console.log,
+            async: callback
+        };
 
         beforeEach(function(){
             // runs before each test in this block
@@ -84,10 +95,10 @@ describe('StringReplacePlugin', function(){
         it('should replace strings in source', function(){
             plugin.apply(mockConfig);
             mockConfig.query = query;
-            var replaced = loader.call(mockConfig, "some string");
+            loader.call(mockConfig, "some string");
             assert(replaced === "some string", "doesn't modify when there are no matches");
 
-            replaced = loader.call(mockConfig, "some <!-- @secret stuff --> string");
+            loader.call(mockConfig, "some <!-- @secret stuff --> string");
             assert.equal(replaced, "some replaced ==>stuff<== string", "replaces matches");
         });
 
@@ -111,10 +122,10 @@ describe('StringReplacePlugin', function(){
 
             mockConfig.query = query;
 
-            var replaced = loader.call(mockConfig, "some string");
+            loader.call(mockConfig, "some string");
             assert(replaced === "some string", "doesn't modify when there are no matches");
 
-            replaced = loader.call(mockConfig, "some <!-- @secret stuff --> string");
+            loader.call(mockConfig, "some <!-- @secret stuff --> string");
             assert.equal(replaced, "some replaced ==>stuff<== string", "replaces matches");
         });
     })


### PR DESCRIPTION
I use `string-replace-webpack-plugin` together with `extract-text-webpack-plugin` for CSS in this way:

```
loader: StringReplacePlugin.replace(
  ExtractTextPlugin.extract('css-loader?sourceMap'), {
    replacements: [...]
  }, 'stylus-loader?sourceMap')
```

The sourcemap generated by `stylus-loader` disappears after replacement.

Or perhaps there are other ways to use these two plugins together?
