### PR TITLE
Move example dependencies to optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,14 +8,16 @@
   },
   "dependencies": {
     "async": "~0.2.10",
-    "css-loader": "^0.9.1",
-    "file-loader": "^0.8.1",
-    "loader-utils": "~0.2.3",
-    "style-loader": "^0.8.3"
+    "loader-utils": "~0.2.3"
   },
   "devDependencies": {
     "mocha": "^2.2.1",
     "webpack": "*"
+  },
+  "optionalDependencies": {
+    "css-loader": "^0.9.1",
+    "file-loader": "^0.8.1",
+    "style-loader": "^0.8.3"
   },
   "homepage": "http://github.com/jamesandersen/string-replace-webpack-plugin",
   "repository": {


### PR DESCRIPTION
Prevent `css`, `file` and `style` loaders (used in example) from being installed as hard dependencies.
