### PR TITLE
Update webpack version in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "James Andersen @jandersen78",
   "description": "Replace string tokens in the contents of a file.",
   "peerDependencies": {
-    "webpack": "^1.4.2"
+    "webpack": "^1.4.2 || >=2.2.0-rc.0"
   },
   "dependencies": {
     "async": "~0.2.10",


### PR DESCRIPTION
When using the plugin with `webpack >=2` **npm** warns about unresolved peer dependencies:

> npm WARN string-replace-webpack-plugin@0.0.4 requires a peer of webpack@^1.4.2 but none was installed.

I've added `>=2.2.0-rc.0` to the range. I've chosen `2.2.0-rc.0` because it seems that there were some issues with [`2.1.0-beta.27`](https://github.com/jamesandersen/string-replace-webpack-plugin/issues/20).