### PR TITLE
update project to fit webpack2

### DIFF
--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -18,22 +18,25 @@ module.exports = {
 		loaders: [
 			{ test: /\.css$/, loader: "style-loader!css-loader?sourceMap"},
 			{ test: /\.png$/, loader: "file-loader" },
-            { test: /\.html$/,    loader: "file?name=[path][name].[ext]" }, // copies the files over
-            { test: /index.html$/, loader: StringReplacePlugin.replace({
-                replacements: [
-                    {
-                        pattern: /<!-- @secret (\w*?) -->/ig,
-                        replacement: function (match, p1, offset, string) {
-                            return secrets.web[p1];
-                        }
-                    }
-                ]})
-            },
+      { test: /\.html$/,    loader: "file-loader?name=[path][name].[ext]" }, // copies the files over
+      { test: /index.html$/, loader: StringReplacePlugin.replace({
+          replacements: [
+              {
+                  pattern: /<!-- @secret (\w*?) -->/ig,
+                  replacement: function (match, p1, offset, string) {
+                      return secrets.web[p1];
+                  }
+              }
+          ]})
+      },
 		]
 	},
 	devtool: "sourcemap",
 	plugins: [
 		new StringReplacePlugin(),
-		new webpack.optimize.CommonsChunkPlugin("c", "c.js")
+    new webpack.optimize.CommonsChunkPlugin({
+      name: "c",
+      filename: "c.js"
+    })
 	]
 };

--- a/index.js
+++ b/index.js
@@ -6,7 +6,10 @@
 var opts = {};
 
 function StringReplacePlugin() {}
-StringReplacePlugin.REPLACE_OPTIONS = '_string-replace-plugin-options';
+
+// export the replacement options
+// so that the loader can refer to them
+StringReplacePlugin.REPLACE_OPTIONS = opts;
 
 module.exports = StringReplacePlugin;
 
@@ -49,7 +52,4 @@ StringReplacePlugin.replace = function(nextLoaders, replaceOptions, prevLoaders)
 
 
 StringReplacePlugin.prototype.apply = function(compiler) {
-	// add the replacement options onto the compiler options
-    // so that the loader can refer to them
-    compiler.options[StringReplacePlugin.REPLACE_OPTIONS] = opts;
 };

--- a/loader.js
+++ b/loader.js
@@ -8,7 +8,7 @@ var StringReplacePlugin = require('./index.js');
 module.exports = function(source) {
     var id = loaderUtils.parseQuery(this.query).id;
 
-    var stringReplaceOptions = this.options[StringReplacePlugin.REPLACE_OPTIONS];
+    var stringReplaceOptions = StringReplacePlugin.REPLACE_OPTIONS;
     if(!stringReplaceOptions.hasOwnProperty(id)) {
         this.emitWarning('no replacement options found for id ' + id);
     } else {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "mocha": "^2.2.1",
-    "webpack": "*"
+    "webpack": "^2.2.1"
   },
   "optionalDependencies": {
     "css-loader": "^0.9.1",


### PR DESCRIPTION
When using this plugin with webpack2.2.1, an error accoour:
```
TypeError: Cannot read property 'hasOwnProperty' of undefined
 .../string-replace-webpack-plugin/loader.js:12:29)
```
This plugin add custom propertie [`options`](https://github.com/jamesandersen/string-replace-webpack-plugin/blob/v0.0.2/index.js#L54) to webpack compiler object. but [webpack 2 no longer allows custom properties in configuration](https://github.com/webpack/webpack/blob/ecc2adbbfac51776355add90c24481a42f0cb519/lib/WebpackOptionsValidationError.js#L132). 

So I use `StringReplacePlugin` static property `REPLACE_OPTIONS` to store plugin's options and solve this error.