### PR TITLE
Add optional ID parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ StringReplacePlugin.replace([nextLoaders: string], options, [prevLoaders: string
   * `replacements` disables the plugin
     * `pattern` a regex to match against the file contents
     * `replacement` an ECMAScript [string replacement function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_function_as_a_parameter)
+    * `id` an optional id. defaults to a random string
 * `prevLoaders` loaders to apply prior to the replacement
 
 ## License

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ StringReplacePlugin.replace = function(nextLoaders, replaceOptions, prevLoaders)
         throw new Error("Invalid options for StringReplaceOptions.  Ensure the options objects has an array of replacements");
     }
 
-    var id = Math.random().toString(36).slice(2);
+    var id = replaceOptions.id && replaceOptions.id.length ? replaceOptions.id : Math.random().toString(36).slice(2);
     opts[id] = replaceOptions;
     var replaceLoader = require.resolve("./loader") + "?id=" + id,
         val = replaceLoader;


### PR DESCRIPTION
Hey!

This is a potential solution for #25 to make the plugin compatible with webpack's `recordsPath` option. It allows for an `id` to be passed in instead of a randomly generating string.

Let me know what you think, and if you're happy with the concept I'll see about writing some tests.