### PR TITLE
chore: move optionalDependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,13 +11,11 @@
     "loader-utils": "~0.2.3"
   },
   "devDependencies": {
-    "mocha": "^2.2.1",
-    "webpack": "^2.2.1"
-  },
-  "optionalDependencies": {
     "css-loader": "^0.9.1",
     "file-loader": "^0.8.1",
-    "style-loader": "^0.8.3"
+    "mocha": "^2.2.1",
+    "style-loader": "^0.8.3",
+    "webpack": "^2.2.1"
   },
   "homepage": "http://github.com/jamesandersen/string-replace-webpack-plugin",
   "repository": {


### PR DESCRIPTION
Rationale: yarn installs optionalDependencies by default and these particular ones are only needed for the example project.