### PR TITLE
Removing bind so this works with externally defined replacements

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -17,7 +17,7 @@ module.exports = function(source, map) {
 
         if(typeof source === "string") {
             options.replacements.forEach(function(repl) {
-                source = source.replace(repl.pattern, repl.replacement.bind(this));
+                source = source.replace(repl.pattern, repl.replacement);
             }, this);
         } else {
             this.emitWarning("'source' received by loader was not a string");


### PR DESCRIPTION
I have a shared list of replacements that I share across build systems, by removing the `bind(this)` the replacements work otherwise I get the following error:

```
Module build failed: TypeError: repl.replacement.bind is not a function
    at Object.<anonymous> (/Users/samuelmburu/workspace/productivity/survata-com/node_modules/string-replace-webpack-plugin/loader.js:20:72)
    at Array.forEach (<anonymous>)
    at Object.module.exports (/Users/samuelmburu/workspace/productivity/survata-com/node_modules/string-replace-webpack-plugin/loader.js:19:34)
```